### PR TITLE
Annotate CheckBoxParam With ReflectionMarker

### DIFF
--- a/src/main/java/ch/alpine/bridge/ref/FieldsEditorParam.java
+++ b/src/main/java/ch/alpine/bridge/ref/FieldsEditorParam.java
@@ -40,6 +40,7 @@ public class FieldsEditorParam {
   public Boolean textFieldFont_override = false;
   public Font textFieldFont = new Font(Font.DIALOG_INPUT, Font.PLAIN, 15);
 
+  @ReflectionMarker
   public static class CheckBoxParam {
     /** icon applicable to {@link BooleanCheckBox} */
     public Boolean override = false;


### PR DESCRIPTION
Annotate `FieldsEditorParam#CheckBoxParam` with `@ReflectionMarker` as it is currently detected as missing by `ReflectionMarkers`